### PR TITLE
implment conflicting feedId guard

### DIFF
--- a/x/chainlink/keeper/keeper.go
+++ b/x/chainlink/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -218,6 +219,14 @@ func (k Keeper) GetModuleOwnerList(ctx sdk.Context) *types.GetModuleOwnerRespons
 
 func (k Keeper) SetFeed(ctx sdk.Context, feed *types.MsgFeed) (int64, []byte) {
 	feedStore := ctx.KVStore(k.feedStoreKey)
+
+	potFeedKey := types.KeyPrefix(types.FeedKey + feed.FeedId)
+	feedIdBytes := feedStore.Get(potFeedKey)
+
+	if len(feedIdBytes) != 0 {
+		// return height and empty bytes for conflicting feedId
+		return ctx.BlockHeight(), []byte{}
+	}
 
 	f := k.cdc.MustMarshalBinaryBare(feed)
 

--- a/x/chainlink/keeper/msg_server.go
+++ b/x/chainlink/keeper/msg_server.go
@@ -73,6 +73,11 @@ func (k Keeper) AddFeedTx(c context.Context, msg *types.MsgFeed) (*types.MsgResp
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "incorrect height found")
 	}
 
+	// return 0 length bytes in keeper.SetFeed(ctx, msg) if conflicting feedId
+	if len(txHash) == 0 {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "conflicting feedId found")
+	}
+
 	return &types.MsgResponse{
 		Height: uint64(height),
 		TxHash: string(txHash),


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Description
Implements a way for the keeper to know if a feed Id has already been set or not.


## Changes

- keeper.go
- msg_server.go
- 

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #?
