### PR TITLE
Add MIT license + SDPX headers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint and License Headers
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -20,3 +20,5 @@ jobs:
         with:
           version: v1.36
           args: --timeout=5m
+      - name: License Check
+        run: make license-check

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 ChainSafe Systems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 ###                                   Lint                                  ###
 ###############################################################################
 
-.PHONY: help lint test
+.PHONY: help lint test license
 all: help
 help: Makefile
 	@echo
@@ -62,3 +62,20 @@ test-addFeed:
 
 protogen:
 	./scripts/protocgen
+
+
+###############################################################################
+###                                   License                               ###
+###############################################################################
+
+## license: Adds license header to missing files.
+license:
+	@echo "  >  \033[32mAdding license headers...\033[0m "
+	GO111MODULE=off go get -u github.com/google/addlicense
+	addlicense -c "ChainSafe Systems" -f ./scripts/header.txt -y 2021 ./x
+
+## license-check: Checks for missing license headers
+license-check:
+	@echo "  >  \033[Checking for license headers...\033[0m "
+	GO111MODULE=off go get -u github.com/google/addlicense
+	addlicense -check -c "ChainSafe Systems" -f ./scripts/header.txt -y 2021 ./x

--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ $ make start
 ## Learn more
 - [Cosmos SDK documentation](https://docs.cosmos.network)
 - [Cosmos SDK Tutorials](https://tutorials.cosmos.network)
- 
+
+## License
+
+[MIT](LICENSE) © ChainSafe Systems

--- a/scripts/header.txt
+++ b/scripts/header.txt
@@ -1,0 +1,2 @@
+Copyright 2021 ChainSafe Systems
+SPDX-License-Identifier: MIT

--- a/x/chainlink/ante/ante.go
+++ b/x/chainlink/ante/ante.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package ante
 
 import (

--- a/x/chainlink/ante/ante.go
+++ b/x/chainlink/ante/ante.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package ante

--- a/x/chainlink/client/cli/genModuleOwner.go
+++ b/x/chainlink/client/cli/genModuleOwner.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package cli

--- a/x/chainlink/client/cli/genModuleOwner.go
+++ b/x/chainlink/client/cli/genModuleOwner.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/x/chainlink/client/cli/query.go
+++ b/x/chainlink/client/cli/query.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package cli

--- a/x/chainlink/client/cli/query.go
+++ b/x/chainlink/client/cli/query.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/x/chainlink/client/cli/queryFeed.go
+++ b/x/chainlink/client/cli/queryFeed.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package cli

--- a/x/chainlink/client/cli/queryFeed.go
+++ b/x/chainlink/client/cli/queryFeed.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/x/chainlink/client/cli/queryModuleInfo.go
+++ b/x/chainlink/client/cli/queryModuleInfo.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package cli

--- a/x/chainlink/client/cli/queryModuleInfo.go
+++ b/x/chainlink/client/cli/queryModuleInfo.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/x/chainlink/client/cli/tx.go
+++ b/x/chainlink/client/cli/tx.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package cli

--- a/x/chainlink/client/cli/tx.go
+++ b/x/chainlink/client/cli/tx.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/x/chainlink/client/cli/txFeed.go
+++ b/x/chainlink/client/cli/txFeed.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package cli

--- a/x/chainlink/client/cli/txFeed.go
+++ b/x/chainlink/client/cli/txFeed.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/x/chainlink/client/cli/txModuleInfo.go
+++ b/x/chainlink/client/cli/txModuleInfo.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package cli

--- a/x/chainlink/client/cli/txModuleInfo.go
+++ b/x/chainlink/client/cli/txModuleInfo.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/x/chainlink/client/rest/rest.go
+++ b/x/chainlink/client/rest/rest.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package rest
 
 import (

--- a/x/chainlink/client/rest/rest.go
+++ b/x/chainlink/client/rest/rest.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package rest

--- a/x/chainlink/client/rest/types.go
+++ b/x/chainlink/client/rest/types.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package rest

--- a/x/chainlink/client/rest/types.go
+++ b/x/chainlink/client/rest/types.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package rest
 
 import "github.com/cosmos/cosmos-sdk/types/rest"

--- a/x/chainlink/genesis.go
+++ b/x/chainlink/genesis.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package chainlink

--- a/x/chainlink/genesis.go
+++ b/x/chainlink/genesis.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package chainlink
 
 import (

--- a/x/chainlink/handler.go
+++ b/x/chainlink/handler.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package chainlink

--- a/x/chainlink/handler.go
+++ b/x/chainlink/handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package chainlink
 
 import (

--- a/x/chainlink/keeper/grpc_query.go
+++ b/x/chainlink/keeper/grpc_query.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package keeper

--- a/x/chainlink/keeper/grpc_query.go
+++ b/x/chainlink/keeper/grpc_query.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package keeper
 
 import (

--- a/x/chainlink/keeper/keeper.go
+++ b/x/chainlink/keeper/keeper.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package keeper

--- a/x/chainlink/keeper/keeper.go
+++ b/x/chainlink/keeper/keeper.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package keeper
 
 import (

--- a/x/chainlink/keeper/keeper_test.go
+++ b/x/chainlink/keeper/keeper_test.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package keeper

--- a/x/chainlink/keeper/keeper_test.go
+++ b/x/chainlink/keeper/keeper_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package keeper
 
 import (

--- a/x/chainlink/keeper/msg_server.go
+++ b/x/chainlink/keeper/msg_server.go
@@ -1,6 +1,6 @@
-package keeper
-
 // SPDX-License-Identifier: MIT
+
+package keeper
 
 import (
 	"context"

--- a/x/chainlink/keeper/msg_server.go
+++ b/x/chainlink/keeper/msg_server.go
@@ -1,5 +1,7 @@
 package keeper
 
+// SPDX-License-Identifier: MIT
+
 import (
 	"context"
 

--- a/x/chainlink/keeper/msg_server.go
+++ b/x/chainlink/keeper/msg_server.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package keeper

--- a/x/chainlink/keeper/querier.go
+++ b/x/chainlink/keeper/querier.go
@@ -1,5 +1,7 @@
 package keeper
 
+// SPDX-License-Identifier: MIT
+
 import (
 	"github.com/ChainSafe/chainlink-cosmos/x/chainlink/types"
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/chainlink/keeper/querier.go
+++ b/x/chainlink/keeper/querier.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package keeper

--- a/x/chainlink/keeper/querier.go
+++ b/x/chainlink/keeper/querier.go
@@ -1,6 +1,6 @@
-package keeper
-
 // SPDX-License-Identifier: MIT
+
+package keeper
 
 import (
 	"github.com/ChainSafe/chainlink-cosmos/x/chainlink/types"

--- a/x/chainlink/keeper/util.go
+++ b/x/chainlink/keeper/util.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package keeper

--- a/x/chainlink/keeper/util.go
+++ b/x/chainlink/keeper/util.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package keeper
 
 import (

--- a/x/chainlink/module.go
+++ b/x/chainlink/module.go
@@ -1,3 +1,4 @@
+// Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: MIT
 
 package chainlink

--- a/x/chainlink/module.go
+++ b/x/chainlink/module.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package chainlink
 
 import (

--- a/x/chainlink/types/codec.go
+++ b/x/chainlink/types/codec.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: MIT
+
 package types
 
 import (

--- a/x/chainlink/types/errors.go
+++ b/x/chainlink/types/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: MIT
+
 package types
 
 // DONTCOVER

--- a/x/chainlink/types/genesis.go
+++ b/x/chainlink/types/genesis.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: MIT
+
 package types
 
 import (

--- a/x/chainlink/types/keys.go
+++ b/x/chainlink/types/keys.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: MIT
+
 package types
 
 const (

--- a/x/chainlink/types/msg.go
+++ b/x/chainlink/types/msg.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: MIT
+
 package types
 
 import (

--- a/x/chainlink/types/querier.go
+++ b/x/chainlink/types/querier.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: MIT
+
 package types
 
 // Supported endpoints

--- a/x/chainlink/types/types.go
+++ b/x/chainlink/types/types.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: MIT
+
 package types
 
 import (


### PR DESCRIPTION
## Description

Add MIT license to Chainlink Cosmos project

## Changes

- Add MIT `LICENSE` file
- Link license file in `README.md`
- Add `SPDX` header in each `.go` file in `x` package
